### PR TITLE
Support Linux and macOS; produce static library rather than shared library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,26 @@
-CFLAGS :=  -std=c++20 -fPIC # do not include -fPIC if static library
-LDFLAGS := -Wl,-Bstatic -lginac -lcln -lgmp -static-libstdc++ # this is more portable, but idk if it will work for all installs
 SOURCES=$(src/)
 HEADERS=$(src/headers/)
+
+UNAME_S := $(shell uname -s)
+
+ifeq ($(UNAME_S),Darwin)
+	CFLAGS :=  -std=c++17 -arch x86_64
+	LDFLAGS := -Wl,-v -lginac -lcln -lgmp -static-libstdc++
+else
+	CFLAGS :=  -std=c++17
+	LDFLAGS := -Wl,-Bstatic -lginac -lcln -lgmp -static-libstdc++ # this is more portable, but idk if it will work for all installs
+endif
 
 #Makefile Targets
 out/%.o: src/%.cpp
 	$(CXX) $(CFLAGS) -c -o $@ $^ $(LDFLAGS)
 
-out/library.so: out/utils.o  out/lin_alg.o out/lie_algebra.o
-	$(CXX) $(CFLAGS) -shared -o $@ $^ # $(LDFLAGS)
-# mv $@ out/$@
-#	ar rvs $@ $^
-# We need to change this to get a shared library if matlab wants it
-#mv $@ out/$@
+out/library.a: out/utils.o out/lin_alg.o out/lie_algebra.o
+#	$(CXX) $(CFLAGS) -shared -o $@ $^ # $(LDFLAGS)
+	ar rcs $@ $^
 
-out/test.o: src/test.cpp out/library.so #out/library.a
+out/test.o: src/test.cpp out/library.a
 	$(CXX) $(CFLAGS) -o $@ $^ $(LDFLAGS)
-#mv $@ out/$@
 
 out/example.o: src/example.cpp out/library.so #out/library.a
 	$(CXX) $(CFLAGS) -o $@ $^ $(LDFLAGS)

--- a/src/lie_algebra.cpp
+++ b/src/lie_algebra.cpp
@@ -158,7 +158,7 @@ mat_vec lie_algebra::compute_normalizer_element(g::matrix x, mat_vec M) {
     mat_vec alpha = this->extend_basis(sl_alg);
 
     // Let H be the span of the remaining basis elements of sl not in L. Let P (proj) be the projection onto H, in the basis alpha.
-    g::matrix proj = {sl_alg->get_dim(), sl_alg->get_dim()};
+    g::matrix proj = {static_cast<unsigned int>(sl_alg->get_dim()), static_cast<unsigned int>(sl_alg->get_dim())};
     for (int i = this->get_dim(); i < sl_alg->get_dim(); i++) {
         proj(i,i) = 1;
     }
@@ -204,7 +204,7 @@ int lie_algebra::max_rank() {
     mat_vec matrices = this-> basis;
 
     // We set lin_comb = x_1 M_1 + ... + x_k M_k.
-    g::matrix lin_comb = {this->sl_size, this-> sl_size};
+    g::matrix lin_comb = {static_cast<unsigned int>(this->sl_size), static_cast<unsigned int>(this-> sl_size)};
     for(int i = 0; i < matrices.size(); i++){
         g::symbol x_i("x_" + i);
         lin_comb = lin_comb.add(matrices[i].mul_scalar(x_i));


### PR DESCRIPTION
Static library makes the MATLAB interface more portable (two library files compared to three).
Not sure whether the Makefile works on Linux.

Some compilers complain about a narrowing error from int to unsigned int; this is resolved with explicit casts.